### PR TITLE
Mark/disable unused tests (for now).

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -64,14 +64,15 @@ const (
 )
 
 var _ = BeforeSuite(func() {
-	if useActualController {
-		// this cleans up
-		client, _ := NewClientAndProject(tenantName, controllerAddr, controllerPort)
-		CleanupLingeringVM(client, containerID)
-	}
+	// Code disabled: cannot mark 'BeforeSuite' block as Pending...
+	// if useActualController {
+	// 	// this cleans up
+	// 	client, _ := NewClientAndProject(tenantName, controllerAddr, controllerPort)
+	// 	CleanupLingeringVM(client, containerID)
+	// }
 })
 
-var _ = Describe("Controller", func() {
+var _ = PDescribe("Controller", func() {
 
 	var client *Controller
 	var project *types.Project
@@ -460,7 +461,7 @@ var _ = Describe("Controller", func() {
 	})
 })
 
-var _ = Describe("Authenticating", func() {
+var _ = PDescribe("Authenticating", func() {
 
 	type TestCase struct {
 		shouldErr bool

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -83,12 +83,14 @@ func TestDriver(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	vswitchName = strings.Replace(vswitchNameWildcard, "<adapter>", netAdapter, -1)
-	cleanupAll()
+	// Code disabled: cannot mark 'BeforeSuite' block as Pending...
+	// vswitchName = strings.Replace(vswitchNameWildcard, "<adapter>", netAdapter, -1)
+	// cleanupAll()
 })
 
 var _ = AfterSuite(func() {
-	cleanupAll()
+	// Code disabled: cannot mark 'BeforeSuite' block as Pending...
+	// cleanupAll()
 })
 
 func cleanupAll() {
@@ -129,7 +131,7 @@ type OneTimeListener struct {
 	Received chan (interface{})
 }
 
-var _ = Describe("Contrail Network Driver", func() {
+var _ = PDescribe("Contrail Network Driver", func() {
 
 	BeforeEach(func() {
 		contrailDriver, contrailController, hnsMgr, project = startDriver()
@@ -314,7 +316,7 @@ var _ = Describe("Contrail Network Driver", func() {
 	})
 })
 
-var _ = Describe("On requests from docker daemon", func() {
+var _ = PDescribe("On requests from docker daemon", func() {
 
 	var docker *dockerClient.Client
 

--- a/hns/hns_test.go
+++ b/hns/hns_test.go
@@ -57,17 +57,19 @@ func TestHNS(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	err := common.HardResetHNS()
-	Expect(err).ToNot(HaveOccurred())
-	err = networking_acl.WaitForValidIPReacquisition(common.AdapterName(netAdapter))
-	Expect(err).ToNot(HaveOccurred())
+	// Code disabled: cannot mark 'BeforeSuite' block as Pending...
+	// err := common.HardResetHNS()
+	// Expect(err).ToNot(HaveOccurred())
+	// err = networking_acl.WaitForValidIPReacquisition(common.AdapterName(netAdapter))
+	// Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {
-	err := common.HardResetHNS()
-	Expect(err).ToNot(HaveOccurred())
-	err = networking_acl.WaitForValidIPReacquisition(common.AdapterName(netAdapter))
-	Expect(err).ToNot(HaveOccurred())
+	// Code disabled: cannot mark 'BeforeSuite' block as Pending...
+	// err := common.HardResetHNS()
+	// Expect(err).ToNot(HaveOccurred())
+	// err = networking_acl.WaitForValidIPReacquisition(common.AdapterName(netAdapter))
+	// Expect(err).ToNot(HaveOccurred())
 })
 
 const (
@@ -77,7 +79,7 @@ const (
 	defaultGW   = "10.0.0.1"
 )
 
-var _ = Describe("HNS wrapper", func() {
+var _ = PDescribe("HNS wrapper", func() {
 
 	var originalNumNetworks int
 
@@ -404,7 +406,7 @@ var _ = Describe("HNS wrapper", func() {
 	})
 })
 
-var _ = Describe("HNS race conditions workarounds", func() {
+var _ = PDescribe("HNS race conditions workarounds", func() {
 
 	var targetAddr string
 	const (

--- a/hnsManager/hns_manager_test.go
+++ b/hnsManager/hns_manager_test.go
@@ -43,13 +43,14 @@ func TestHNSManager(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	err := common.HardResetHNS()
-	Expect(err).ToNot(HaveOccurred())
-	err = networking_acl.WaitForValidIPReacquisition(common.AdapterName(netAdapter))
-	Expect(err).ToNot(HaveOccurred())
+	// Code disabled: cannot mark 'BeforeSuite' block as Pending...
+	// err := common.HardResetHNS()
+	// Expect(err).ToNot(HaveOccurred())
+	// err = networking_acl.WaitForValidIPReacquisition(common.AdapterName(netAdapter))
+	// Expect(err).ToNot(HaveOccurred())
 })
 
-var _ = Describe("HNS manager", func() {
+var _ = PDescribe("HNS manager", func() {
 
 	const (
 		tenantName  = "agatka"


### PR DESCRIPTION
Currently, there is an explicit whitelist of modules(packages) to build and test.

This proved painful when I started creating new packages.

Fix involves using Pending mechanism where possible, and commenting out unused test code where it wasn't (mainly in Before/AfterSuite blocks).

Complementary PR that will enable running of those tests in CI: https://github.com/Juniper/contrail-windows-ci/pull/139